### PR TITLE
Add builtin packages

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,4 @@
 combined.json
 cache/*.json
+cache/*.sql
+cache/*.sqlite

--- a/data/Makefile
+++ b/data/Makefile
@@ -29,4 +29,5 @@ cache/epkg.sql:
 
 # SQLite database for read
 cache/epkgs.sqlite: cache/epkg.sql
+	rm cache/epkgs.sqlite
 	sqlite3 cache/epkgs.sqlite '.read cache/epkg.sql'

--- a/data/Makefile
+++ b/data/Makefile
@@ -12,7 +12,7 @@ finder-known-keywords.json:
 combined.json: cache node_modules
 	bun collectData.ts
 
-cache: cache/gnu.json cache/nongnu.json cache/jcs.json
+cache: cache/gnu.json cache/nongnu.json cache/jcs.json cache/epkgs.sqlite
 
 cache/gnu.json:
 	sh ./elpa-to-json cache/gnu.json "https://elpa.gnu.org/packages/"
@@ -22,3 +22,11 @@ cache/nongnu.json:
 
 cache/jcs.json:
 	sh ./elpa-to-json cache/jcs-elpa.json "https://jcs-emacs.github.io/jcs-elpa/packages/"
+
+# The textual version
+cache/epkg.sql:
+	curl -L "https://github.com/emacsmirror/epkgs/raw/refs/heads/master/epkg.sql" > cache/epkg.sql
+
+# SQLite database for read
+cache/epkgs.sqlite: cache/epkg.sql
+	sqlite3 cache/epkgs.sqlite '.read epkg.sql'

--- a/data/Makefile
+++ b/data/Makefile
@@ -29,4 +29,4 @@ cache/epkg.sql:
 
 # SQLite database for read
 cache/epkgs.sqlite: cache/epkg.sql
-	sqlite3 cache/epkgs.sqlite '.read epkg.sql'
+	sqlite3 cache/epkgs.sqlite '.read cache/epkg.sql'

--- a/data/collectData.ts
+++ b/data/collectData.ts
@@ -4,10 +4,21 @@ import {
   elpaConvertedJson,
   melpaRecipesJson,
   melpaRecipeToUrl,
+  epkgsSqlBuiltinPackages,
+  stringOfJsonString,
+  epkgsSqlPeople,
+  epkgsSqlStrings,
 } from "./schema.ts";
-import type { Pkg } from "./schema.ts";
+import type { EpkgsSqlPeople, Pkg } from "./schema.ts";
+import { Database } from "bun:sqlite";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { $ } from "zx";
+
+const epkgs = new Database("cache/epkgs.sqlite", {
+  readonly: true,
+  create: false,
+  strict: true,
+});
 
 /**
  * Fetch ELPA archive-contents from `url`, convert it to JSON, then return the value.
@@ -110,64 +121,166 @@ const elpas = {
 
 const packages: Pkg[] = [];
 
-for (const [archiveName, pkgs] of Object.entries(elpas)) {
-  for (const [pkgName, [version, deps, desc, _kind, props]] of Object.entries(
-    pkgs,
+function insertElpas() {
+  for (const [archiveName, pkgs] of Object.entries(elpas)) {
+    for (const [pkgName, [version, deps, desc, _kind, props]] of Object.entries(
+      pkgs,
+    )) {
+      const newPkg: Pkg = {
+        name: pkgName,
+        archive: archiveName,
+        ver: version,
+        deps: deps,
+        summary: desc,
+      };
+      // Not misspell, the input is always singular while we want output to be plural
+      if (props?.maintainer) newPkg.maintainers = props.maintainer;
+      if (props?.authors) newPkg.authors = props.authors;
+      if (props?.keywords) newPkg.keywords = props.keywords;
+      if (props?.commit) newPkg.commit = props.commit;
+      if (props?.url) newPkg.url = props.url;
+
+      packages.push(newPkg);
+    }
+  }
+}
+
+function insertMelpas() {
+  for (const [archiveName, { archive, downloads, recipes }] of Object.entries(
+    melpas,
   )) {
-    const newPkg: Pkg = {
-      name: pkgName,
-      archive: archiveName,
-      ver: version,
-      deps: deps,
-      summary: desc,
-    };
-    // Not misspell, the input is always singular while we want output to be plural
-    if (props?.maintainer) newPkg.maintainers = props.maintainer;
-    if (props?.authors) newPkg.authors = props.authors;
-    if (props?.keywords) newPkg.keywords = props.keywords;
-    if (props?.commit) newPkg.commit = props.commit;
-    if (props?.url) newPkg.url = props.url;
+    for (const [pkgName, { ver, deps, desc, props }] of Object.entries(
+      archive,
+    )) {
+      const newPkg: Pkg = {
+        name: pkgName,
+        archive: archiveName,
+        ver: ver,
+        deps: deps,
+        summary: desc,
+      };
+      if (downloads[pkgName]) {
+        newPkg.downloads = downloads[pkgName];
+      }
+      if (props.maintainers) newPkg.maintainers = props.maintainers;
+      if (props.authors) newPkg.authors = props.authors;
+      if (props.keywords) newPkg.keywords = props.keywords;
+      if (props.commit) newPkg.commit = props.commit;
+      // throwing away revdesc
 
+      const recipe = recipes[pkgName];
+      if (recipe) {
+        const recipeUrl = melpaRecipeToUrl(recipe);
+        newPkg.url = recipeUrl;
+      } else if (props.url) {
+        // fall back to the URL the package itself declares
+        console.log(
+          `${pkgName} has no URL in its recipe, somehow. Falling back to ${props.url}`,
+        );
+        newPkg.url = props.url;
+      }
+
+      packages.push(newPkg);
+    }
+  }
+}
+
+function epkgsPeopleToStrings(people: EpkgsSqlPeople) {
+  return people.map(({ name, email }) => {
+    const parsedName =
+      typeof name === "string" ? stringOfJsonString.parse(name) : name;
+    const parsedEmail =
+      typeof email === "string" ? stringOfJsonString.parse(email) : email;
+    const namePresent = typeof parsedName === "string";
+    const emailPresent = typeof parsedEmail === "string";
+    if (namePresent && emailPresent) {
+      return `${parsedName} <${parsedEmail}>`;
+    }
+    if (namePresent) {
+      return parsedName;
+    }
+    if (emailPresent) {
+      return parsedEmail;
+    }
+    // This should never happen: either name or email should be present.
+    return "";
+  });
+}
+
+function insertEpkgsBuiltins() {
+  for (const epkgsBuiltinPackage of epkgsSqlBuiltinPackages.parse(
+    epkgs
+      .query(
+        `
+SELECT name, library, homepage, summary, commentary
+FROM packages
+WHERE class = 'builtin'
+  AND name != '"emacs"'`,
+      )
+      .all(),
+  )) {
+    const { name } = epkgsBuiltinPackage;
+    const keywords = epkgsSqlStrings.parse(
+      epkgs
+        .query(
+          `
+SELECT keyword FROM keywords
+WHERE package = ?`,
+        )
+        .values(name)
+        .map((v: unknown[]) => v[0]),
+    );
+    const authors = epkgsSqlPeople.parse(
+      epkgs
+        .query(
+          `
+SELECT name, email FROM authors
+WHERE package = ?`,
+        )
+        .all(name),
+    );
+    const maintainers = epkgsSqlPeople.parse(
+      epkgs
+        .query(
+          `
+SELECT name, email FROM maintainers
+WHERE package = ?`,
+        )
+        .all(name),
+    );
+    const deps = epkgsSqlStrings.parse(
+      epkgs
+        .query(
+          `
+SELECT package FROM provided
+WHERE feature IN (
+  SELECT feature FROM required
+  WHERE package = ?
+)
+`,
+        )
+        .values(name)
+        .map((v: unknown[]) => v[0]),
+    );
+    console.log(name);
+    const newPkg: Pkg = {
+      name: stringOfJsonString.parse(name),
+      archive: "builtin",
+      ver: [],
+      // Forcibly give it an empty versionList
+      deps: Object.fromEntries(deps.map((dep) => [dep, []])),
+      summary: stringOfJsonString.parse(epkgsBuiltinPackage.summary),
+      maintainers: epkgsPeopleToStrings(maintainers),
+      authors: epkgsPeopleToStrings(authors),
+      keywords: keywords,
+    };
     packages.push(newPkg);
   }
 }
 
-for (const [archiveName, { archive, downloads, recipes }] of Object.entries(
-  melpas,
-)) {
-  for (const [pkgName, { ver, deps, desc, props }] of Object.entries(archive)) {
-    const newPkg: Pkg = {
-      name: pkgName,
-      archive: archiveName,
-      ver: ver,
-      deps: deps,
-      summary: desc,
-    };
-    if (downloads[pkgName]) {
-      newPkg.downloads = downloads[pkgName];
-    }
-    if (props.maintainers) newPkg.maintainers = props.maintainers;
-    if (props.authors) newPkg.authors = props.authors;
-    if (props.keywords) newPkg.keywords = props.keywords;
-    if (props.commit) newPkg.commit = props.commit;
-    // throwing away revdesc
-
-    const recipe = recipes[pkgName];
-    if (recipe) {
-      const recipeUrl = melpaRecipeToUrl(recipe);
-      newPkg.url = recipeUrl;
-    } else if (props.url) {
-      // fall back to the URL the package itself declares
-      console.log(
-        `${pkgName} has no URL in its recipe, somehow. Falling back to ${props.url}`,
-      );
-      newPkg.url = props.url;
-    }
-
-    packages.push(newPkg);
-  }
-}
-
+insertElpas();
+insertMelpas();
+insertEpkgsBuiltins();
 writeFileSync(
   "combined.json",
   JSON.stringify({ collectedDate: new Date(), packages: packages }, null, 1),

--- a/data/collectData.ts
+++ b/data/collectData.ts
@@ -185,6 +185,9 @@ function insertMelpas() {
   }
 }
 
+/**
+ * Convert an array of {name,email} objects to strings.
+ */
 function epkgsPeopleToStrings(people: EpkgsSqlPeople) {
   return people.map(({ name, email }) => {
     const parsedName =
@@ -262,13 +265,14 @@ WHERE feature IN (
         .values(name)
         .map((v: unknown[]) => v[0]),
     );
-    console.log(name);
     const newPkg: Pkg = {
       name: stringOfJsonString.parse(name),
       archive: "builtin",
       ver: [],
       // Forcibly give it an empty versionList
-      deps: Object.fromEntries(deps.map((dep) => [dep, []])),
+      deps: Object.fromEntries(
+        deps.map((dep) => [stringOfJsonString.parse(dep), []]),
+      ),
       summary: stringOfJsonString.parse(epkgsBuiltinPackage.summary),
       maintainers: epkgsPeopleToStrings(maintainers),
       authors: epkgsPeopleToStrings(authors),

--- a/data/emacsmirror.org
+++ b/data/emacsmirror.org
@@ -1,0 +1,11 @@
+#+title: Emacsmirror
+#+created: 2025-05-07T00:42:52+0900
+
+Reading data from emacsmirror/epkgs.
+
+Download the texual representation, then import it into a new database called =epkgs.sqlite=
+
+#+begin_src sh
+curl -L "https://github.com/emacsmirror/epkgs/raw/refs/heads/master/epkg.sql" > epkg.sql
+sqlite3 epkgs.sqlite '.read epkg.sql'
+#+end_src

--- a/data/emacsmirror.org
+++ b/data/emacsmirror.org
@@ -9,3 +9,41 @@ Download the texual representation, then import it into a new database called =e
 curl -L "https://github.com/emacsmirror/epkgs/raw/refs/heads/master/epkg.sql" > epkg.sql
 sqlite3 epkgs.sqlite '.read epkg.sql'
 #+end_src
+
+- =var_wikipage= maps emacswiki packages to their pages on emacswiki
+- =var_orphanage= shows orphanage package names and why they are in orphanage
+- =var_homepage= provides package homepages
+- =required= has info on which library requires which other features, including whether it's a soft or hard require
+- =provided= maps packages to features, and can be used to go back from features to packages
+- =packages= has repopage, homepage, mirrorpage (emacsmirror), and wikipage; so =var_wikipage= isn't necessary. It also has both summary and commentary.
+  - It also has =class=. It's named as such due to Emacs Lisp reasons (this database is actually storing Emacs Lisp values), but it provides:
+    - builtin
+    - shelved (emacsattic)
+    - wiki (on main mirror, source is emacswiki)
+    - orphaned (emacsorphanage?)
+- =builtin_libraries= has package, library (file, multiple files = multiple entries), and feature
+
+We should handle different sources here differently. There are 4, roughly:
+
+- emacsattic (but some of these are still on MELPA, right?)
+- emacsorphanage (again, some of these are still on MELPA)
+- emacswiki
+- builtin packages
+
+Builtin packages:
+
+#+begin_src js
+const pkg = z.object({
+  name: nameFromEmacsmirror,
+  archive: "builtin",
+  ver: undefined,
+  deps: ..., // emacsmirror only provides features. Map them back to packages?
+  summary: summaryFromEmacsmirror,
+  downloads: undefined,
+  maintainers: maintainersFromEmacsMirror,
+  authors: authorsFromEmacsMirror,
+  keywords: keywordsFromEmacsMirror,
+  commit: undefined,
+  url: emacsSourceRepoPlusLibraryPathFromEmacsMirror,
+});
+#+end_src

--- a/data/schema.ts
+++ b/data/schema.ts
@@ -206,7 +206,8 @@ export const stringOfJsonString = z
   .string()
   .transform((str, ctx): z.infer<ReturnType<typeof z.string>> => {
     try {
-      const value = JSON.parse(str);
+      // JSON does not allow bare tab characters. Uh, why??
+      const value = JSON.parse(str.replaceAll("\t", ""));
       if (typeof value !== "string") {
         throw "not a string";
       }

--- a/data/schema.ts
+++ b/data/schema.ts
@@ -196,3 +196,52 @@ export function archivePkgUrl(archive: string, pkg: string, fallbackPkg?: Pkg) {
 }
 
 export const finderKnownKeywords = z.record(z.string());
+
+/**
+ * A string that contains JSON that, when parsed, produces a string.
+ * Modified from zod_utilz:
+ * https://github.com/JacobWeisenburger/zod_utilz/blob/4093595e5a6d95770872598ba3bc405d4e9c963b/src/stringToJSON.ts#LL4-L12C8
+ */
+export const stringOfJsonString = z
+  .string()
+  .transform((str, ctx): z.infer<ReturnType<typeof z.string>> => {
+    try {
+      const value = JSON.parse(str);
+      if (typeof value !== "string") {
+        throw "not a string";
+      }
+      return value;
+    } catch (e) {
+      if (e === "not a string") {
+        ctx.addIssue({
+          code: "custom",
+          message: "JSON does not encode a string",
+        });
+      } else {
+        ctx.addIssue({ code: "custom", message: "Invalid JSON" });
+      }
+      return z.NEVER;
+    }
+  });
+
+// We don't parse the strings as JSON just yet because we need the original
+// values for querying more values
+export const epkgsSqlBuiltinPackages = z.array(
+  z.object({
+    name: z.string(),
+    library: z.string(),
+    homepage: z.string(),
+    summary: z.string(),
+    commentary: z.string().nullable(),
+  }),
+);
+
+export const epkgsSqlStrings = z.array(z.string());
+
+export const epkgsSqlPeople = z.array(
+  z.object({
+    name: z.string().nullable(),
+    email: z.string().nullable(),
+  }),
+);
+export type EpkgsSqlPeople = z.infer<typeof epkgsSqlPeople>;

--- a/web/src/components/PaginatedTable.tsx
+++ b/web/src/components/PaginatedTable.tsx
@@ -85,7 +85,8 @@ const columns = [
     },
   }),
   columnHelper.accessor("ver", {
-    cell: (info) => info.getValue().join("."),
+    // exploit empty string being falsy
+    cell: (info) => info.getValue().join(".") || "-",
     header: () => "version",
     enableGlobalFilter: false,
     sortingFn: (rowA, rowB) => {


### PR DESCRIPTION
Add builtin packages as collected by https://github.com/emacsmirror/epkgs/

This allows packages like `avl-tree` to be listed and found.